### PR TITLE
fix translate on Android; alpha release

### DIFF
--- a/example/pages/demo-image-viewer.tsx
+++ b/example/pages/demo-image-viewer.tsx
@@ -5,7 +5,7 @@ import ImageViewer from "../../src/image-viewer";
 import JimoButton from "../../src/jimo-button";
 
 export default function DemoImageViewer() {
-  let [visible, setVisible] = useState(true);
+  let [visible, setVisible] = useState(false);
 
   return (
     <div className={styleContainer}>
@@ -26,8 +26,8 @@ export default function DemoImageViewer() {
         onClose={() => {
           setVisible(false);
         }}
-        hasLeftOne
-        hasRightOne
+        hasLeftOne={false}
+        hasRightOne={false}
       />
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-display",
-  "version": "0.1.1-a1",
+  "version": "0.1.1-a2",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/image-viewer.tsx
+++ b/src/image-viewer.tsx
@@ -110,6 +110,7 @@ export default class ImageViewer extends React.Component<IProps, IState> {
 
     let r90 = currentRotation === EOrientation.r90 || currentRotation === EOrientation.r270;
     let { width, height } = this.state;
+
     return (
       <div className={cx(fullscreen, column, styleContainer)}>
         <div className={cx(flex, stylePreviewArea)}>
@@ -124,9 +125,9 @@ export default class ImageViewer extends React.Component<IProps, IState> {
                   src={this.getImageUrl()}
                   className={styleImage}
                   style={{
-                    translate: r90 ? `${(height - width) / 2}px ${(width - height) / 2}px` : null,
                     transformOrigin: "center",
-                    transform: `rotate(${currentRotation * 90}deg)`,
+                    // translate to get a correct rotation origin, which the center of image
+                    transform: `${r90 ? `translate(${(height - width) / 2}px, ${(width - height) / 2}px) ` : ""}rotate(${currentRotation * 90}deg)`,
                   }}
                   width={this.state.width}
                   height={this.state.height}


### PR DESCRIPTION
`translate` property does not work on Chrome Android. Falling back to `transform: translate()`.