### PR TITLE
sharing dropdown area in preact by removing icons; alpha release

### DIFF
--- a/example/pages/demo-dropdown-area.tsx
+++ b/example/pages/demo-dropdown-area.tsx
@@ -2,6 +2,7 @@ import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import DropdownArea from "../../src/dropdown-area";
 import { expand } from "@jimengio/shared-utils";
+import JimoIcon, { EJimoIcon } from "@jimengio/jimo-icons";
 
 let DemoDropdownArea: FC<{}> = (props) => {
   /** Methods */
@@ -9,7 +10,12 @@ let DemoDropdownArea: FC<{}> = (props) => {
   /** Renderers */
   return (
     <div className={cx(expand, styleContainer)}>
-      <DropdownArea className={styleTrigger} title="A title" renderContent={(onClose) => "Some content"}>
+      <DropdownArea
+        className={styleTrigger}
+        title="A title"
+        renderContent={(onClose) => "Some content"}
+        renderCloseIcon={(className, onClose) => <JimoIcon name={EJimoIcon.slimCross} className={className} onClick={onClose} />}
+      >
         <div>Content with title</div>
       </DropdownArea>
 

--- a/example/pages/demo-dropdown-area.tsx
+++ b/example/pages/demo-dropdown-area.tsx
@@ -2,7 +2,6 @@ import React, { FC, useState } from "react";
 import { css, cx } from "emotion";
 import DropdownArea from "../../src/dropdown-area";
 import { expand } from "@jimengio/shared-utils";
-import JimoIcon, { EJimoIcon } from "@jimengio/jimo-icons";
 
 let DemoDropdownArea: FC<{}> = (props) => {
   /** Methods */

--- a/example/pages/demo-dropdown-area.tsx
+++ b/example/pages/demo-dropdown-area.tsx
@@ -10,12 +10,7 @@ let DemoDropdownArea: FC<{}> = (props) => {
   /** Renderers */
   return (
     <div className={cx(expand, styleContainer)}>
-      <DropdownArea
-        className={styleTrigger}
-        title="A title"
-        renderContent={(onClose) => "Some content"}
-        renderCloseIcon={(className, onClose) => <JimoIcon name={EJimoIcon.slimCross} className={className} onClick={onClose} />}
-      >
+      <DropdownArea className={styleTrigger} title="A title" renderContent={(onClose) => "Some content"}>
         <div>Content with title</div>
       </DropdownArea>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-display",
-  "version": "0.1.8",
+  "version": "0.1.9-a1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-display",
-  "version": "0.1.9-a1",
+  "version": "0.1.9-a2",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-display",
-  "version": "0.1.9-a2",
+  "version": "0.1.9-a3",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/dropdown-area.tsx
+++ b/src/dropdown-area.tsx
@@ -14,15 +14,13 @@ import { rowParted, column, immerHelpers, ImmerStateFunc, MergeStateFunc } from 
 let bus = new EventEmitter();
 let menuEvent = "menu-event";
 
-let svg = `<svg width="44" height="44" xmlns="http://www.w3.org/2000/svg">
+let getSvg = (color: string) => `<svg width="44" height="44" xmlns="http://www.w3.org/2000/svg">
 <path
   d="M22 20.586L41.799.786a1 1 0 1 1 1.414 1.415L23.414 22l19.8 19.799a1 1 0 1 1-1.415 1.414L22 23.414l-19.799 19.8a1 1 0 0 1-1.414-1.415L20.586 22 .786 2.201A1 1 0 0 1 2.202.787L22 20.586z"
-  fill="#BDBDBD"
+  fill="${color}"
   fill-rule="nonzero"
 />
 </svg>`;
-
-let closeIcon = `data:image/svg+xml;base64,${window.btoa(svg)}`;
 
 interface IProps {
   title?: string;
@@ -115,6 +113,8 @@ export default class DropdownArea extends React.Component<IProps, IState> {
   renderDropdown() {
     let { position } = this.state;
 
+    let closeIcon = `data:image/svg+xml;base64,${window.btoa(getSvg("#aaa"))}`;
+
     return ReactDOM.createPortal(
       <div onClick={this.onContainerClick} className={styleAnimations}>
         <CSSTransition in={this.state.visible} unmountOnExit={true} classNames="dropdown" timeout={transitionDuration}>
@@ -135,7 +135,15 @@ export default class DropdownArea extends React.Component<IProps, IState> {
                 <span>{this.props.title}</span>
               </div>
             ) : null}
-            {this.props.hideClose ? null : <span className={styleCloseIcon} onClick={this.onClose}></span>}
+            {this.props.hideClose ? null : (
+              <span
+                className={styleCloseIcon}
+                style={{
+                  backgroundImage: `url(${closeIcon})`,
+                }}
+                onClick={this.onClose}
+              ></span>
+            )}
             {this.props.renderContent(this.onClose)}
           </div>
         </CSSTransition>
@@ -276,7 +284,6 @@ let styleCloseIcon = css`
   right: 16px;
   width: 14px;
   height: 14px;
-  background-image: url(${closeIcon});
   background-size: 14px 14px;
 `;
 

--- a/src/dropdown-area.tsx
+++ b/src/dropdown-area.tsx
@@ -14,14 +14,6 @@ import { rowParted, column, immerHelpers, ImmerStateFunc, MergeStateFunc } from 
 let bus = new EventEmitter();
 let menuEvent = "menu-event";
 
-let getSvg = (color: string) => `<svg width="44" height="44" xmlns="http://www.w3.org/2000/svg">
-<path
-  d="M22 20.586L41.799.786a1 1 0 1 1 1.414 1.415L23.414 22l19.8 19.799a1 1 0 1 1-1.415 1.414L22 23.414l-19.799 19.8a1 1 0 0 1-1.414-1.415L20.586 22 .786 2.201A1 1 0 0 1 2.202.787L22 20.586z"
-  fill="${color}"
-  fill-rule="nonzero"
-/>
-</svg>`;
-
 interface IProps {
   title?: string;
   /** trigger 区域的样式 */
@@ -113,7 +105,15 @@ export default class DropdownArea extends React.Component<IProps, IState> {
   renderDropdown() {
     let { position } = this.state;
 
-    let closeIcon = `data:image/svg+xml;base64,${window.btoa(getSvg("#aaa"))}`;
+    let getSvg = (color: string, width: number, height: number) => (
+      <svg width={width} height={height} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44 44">
+        <path
+          d="M22 20.586L41.799.786a1 1 0 1 1 1.414 1.415L23.414 22l19.8 19.799a1 1 0 1 1-1.415 1.414L22 23.414l-19.799 19.8a1 1 0 0 1-1.414-1.415L20.586 22 .786 2.201A1 1 0 0 1 2.202.787L22 20.586z"
+          fill={color}
+          fillRule="nonzero"
+        />
+      </svg>
+    );
 
     return ReactDOM.createPortal(
       <div onClick={this.onContainerClick} className={styleAnimations}>
@@ -136,13 +136,9 @@ export default class DropdownArea extends React.Component<IProps, IState> {
               </div>
             ) : null}
             {this.props.hideClose ? null : (
-              <span
-                className={styleCloseIcon}
-                style={{
-                  backgroundImage: `url(${closeIcon})`,
-                }}
-                onClick={this.onClose}
-              ></span>
+              <span className={styleCloseIcon} onClick={this.onClose}>
+                {getSvg("#aaa", 14, 14)}
+              </span>
             )}
             {this.props.renderContent(this.onClose)}
           </div>
@@ -282,9 +278,6 @@ let styleCloseIcon = css`
   position: absolute;
   top: 14px;
   right: 16px;
-  width: 14px;
-  height: 14px;
-  background-size: 14px 14px;
 `;
 
 let styleTrigger = css`

--- a/src/dropdown-area.tsx
+++ b/src/dropdown-area.tsx
@@ -14,6 +14,16 @@ import { rowParted, column, immerHelpers, ImmerStateFunc, MergeStateFunc } from 
 let bus = new EventEmitter();
 let menuEvent = "menu-event";
 
+let svg = `<svg width="44" height="44" xmlns="http://www.w3.org/2000/svg">
+<path
+  d="M22 20.586L41.799.786a1 1 0 1 1 1.414 1.415L23.414 22l19.8 19.799a1 1 0 1 1-1.415 1.414L22 23.414l-19.799 19.8a1 1 0 0 1-1.414-1.415L20.586 22 .786 2.201A1 1 0 0 1 2.202.787L22 20.586z"
+  fill="#BDBDBD"
+  fill-rule="nonzero"
+/>
+</svg>`;
+
+let closeIcon = `data:image/svg+xml;base64,${window.btoa(svg)}`;
+
 interface IProps {
   title?: string;
   /** trigger 区域的样式 */
@@ -28,9 +38,6 @@ interface IProps {
   guessHeight?: number;
   renderContent: (onClose: () => void) => ReactNode;
   hideClose?: boolean;
-
-  /** 分离依赖到外部, 默认使用 UTF8 字符 ✕ */
-  renderCloseIcon?: (className: string, onClose: () => void) => ReactNode;
 }
 
 interface IState {
@@ -128,13 +135,7 @@ export default class DropdownArea extends React.Component<IProps, IState> {
                 <span>{this.props.title}</span>
               </div>
             ) : null}
-            {this.props.hideClose ? null : this.props.renderCloseIcon ? (
-              this.props.renderCloseIcon(styleCloseIcon, this.onClose)
-            ) : (
-              <span className={styleCloseIcon} onClick={this.onClose}>
-                ✕
-              </span>
-            )}
+            {this.props.hideClose ? null : <span className={styleCloseIcon} onClick={this.onClose}></span>}
             {this.props.renderContent(this.onClose)}
           </div>
         </CSSTransition>
@@ -273,6 +274,10 @@ let styleCloseIcon = css`
   position: absolute;
   top: 14px;
   right: 16px;
+  width: 14px;
+  height: 14px;
+  background-image: url(${closeIcon});
+  background-size: 14px 14px;
 `;
 
 let styleTrigger = css`

--- a/src/dropdown-area.tsx
+++ b/src/dropdown-area.tsx
@@ -10,7 +10,6 @@ let containerName = "meson-display-container";
 import React, { FC, useEffect, useState, ReactNode, RefObject, CSSProperties } from "react";
 import ReactDOM from "react-dom";
 import { rowParted, column, immerHelpers, ImmerStateFunc, MergeStateFunc } from "@jimengio/shared-utils";
-import JimoIcon, { EJimoIcon } from "@jimengio/jimo-icons";
 
 let bus = new EventEmitter();
 let menuEvent = "menu-event";
@@ -29,6 +28,9 @@ interface IProps {
   guessHeight?: number;
   renderContent: (onClose: () => void) => ReactNode;
   hideClose?: boolean;
+
+  /** 分离依赖到外部, 默认使用 UTF8 字符 ✕ */
+  renderCloseIcon?: (className: string, onClose: () => void) => ReactNode;
 }
 
 interface IState {
@@ -126,7 +128,13 @@ export default class DropdownArea extends React.Component<IProps, IState> {
                 <span>{this.props.title}</span>
               </div>
             ) : null}
-            {this.props.hideClose ? null : <JimoIcon name={EJimoIcon.slimCross} className={styleCloseIcon} onClick={this.onClose} />}
+            {this.props.hideClose ? null : this.props.renderCloseIcon ? (
+              this.props.renderCloseIcon(styleCloseIcon, this.onClose)
+            ) : (
+              <span className={styleCloseIcon} onClick={this.onClose}>
+                ✕
+              </span>
+            )}
             {this.props.renderContent(this.onClose)}
           </div>
         </CSSTransition>


### PR DESCRIPTION
`DropdownArea` 计划独立使用, 需要去掉对 `jimo-icons` 的依赖. 强行改成了 SVG 的依赖.

Preview http://fe.jimu.io/meson-display/#/dropdown-area

https://github.com/jimengio/jimo-icons/blob/master/svg/slim-cross.svg